### PR TITLE
Switch youtube-dl by yt-dlp to improve download speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update
 RUN apt-get install -y python3 ffmpeg
 RUN apt-get install -y python3-pip
 RUN apt-get clean
-RUN python3 -m pip install youtube_dl
+RUN python3 -m pip install -U yt-dlp
 
 ADD musidex-neuralembed ./musidex-neuralembed
 

--- a/musidex-daemon/src/infrastructure/youtube_dl.rs
+++ b/musidex-daemon/src/infrastructure/youtube_dl.rs
@@ -342,17 +342,17 @@ pub async fn ytdl_run_with_args(args: Vec<&str>) -> Result<YoutubeDlOutput> {
     log::info!("running yt dl with args: {}", args.join(" "));
 
     tokio::task::spawn_blocking(move || {
-        let mut child = Command::new("youtube-dl")
+        let mut child = Command::new("yt-dlp")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .args(args)
             .spawn()
-            .context("error starting youtube-dl, did you install it?")?;
+            .context("error starting yt-dlp, did you install it?")?;
         // Continually read from stdout so that it does not fill up with large output and hang forever.
         // We don't need to do this for stderr since only stdout has potentially giant JSON.
         let mut stdout = Vec::new();
         let child_stdout = child.stdout.take();
-        copy(&mut child_stdout.unwrap(), &mut stdout).context("error reading youtube-dl output")?;
+        copy(&mut child_stdout.unwrap(), &mut stdout).context("error reading yt-dlp output")?;
 
         let exit_code = child.wait().context("error while waiting for youtube-dl")?;
 
@@ -360,7 +360,7 @@ pub async fn ytdl_run_with_args(args: Vec<&str>) -> Result<YoutubeDlOutput> {
             let out = String::from_utf8_lossy(stdout.as_slice());
             let out = out.trim();
             let justtype: JustType = nanoserde::DeJson::deserialize_json(out)
-                .context("error decoding youtubedl json")?;
+                .context("error decoding yt-dlp json")?;
 
             let is_playlist = justtype._type.as_deref() == Some("playlist");
             if is_playlist {
@@ -382,7 +382,7 @@ pub async fn ytdl_run_with_args(args: Vec<&str>) -> Result<YoutubeDlOutput> {
             }
             let stderr = String::from_utf8(stderr).unwrap_or_default();
             Err(anyhow!(
-                "error using youtubedl: {} {}",
+                "error using yt-dlp: {} {}",
                 exit_code.code().unwrap_or(1),
                 stderr,
             ))


### PR DESCRIPTION
Just a suggestion to remplace the extractor of youtube video. 
Last months [yt-dlp](https://github.com/yt-dlp/yt-dlp) is gaining more tractions and the project seems to be well maintened.
You can test it on local or in my [instance](http://140.82.53.157:3200/) with this big [video](https://youtu.be/m1x_HjDJQU8) and compare with the current instance.  
The difference is pretty significante (to 1 minute to 10 for youtube-dl !)

Thank you, i like you project :)